### PR TITLE
Deleting sheets by name including upper cases

### DIFF
--- a/script.gs
+++ b/script.gs
@@ -31,10 +31,12 @@ function onOpen() {
       
 function deleteSheets() {
   var deleteSheetsContaining = Browser.inputBox("Delete sheets with names containing:"); 
+   deleteSheetsContaining = deleteSheetsContaining.toLowerCase();
     if (sheetMatch(deleteSheetsContaining)){
       for (var i = 0; i < sheetsCount; i++){
         var sheet = sheets[i]; 
         var sheetName = sheet.getName();
+          sheetName = sheetName.toLowerCase();
         Logger.log(sheetName);
       if (sheetName.indexOf(deleteSheetsContaining.toString()) !== -1){
         Logger.log("DELETE!");


### PR DESCRIPTION
Deleting sheets are case sensitive. Converting everything to lower case would allow the removal of all sheets containing the specified word, regardless of wether there is an upper or lower case.